### PR TITLE
fix: update docs to reference public guilds instead of private lando-agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,9 @@ CAMI creates a user workspace at `~/cami-workspace/` during installation:
 ├── .claude/
 │   └── agents/                  # CAMI's own agents
 ├── sources/                     # Agent sources
-│   ├── official-agents/        # (if added)
+│   ├── my-agents/              # User's custom agents
 │   ├── team-agents/            # (if added)
-│   └── my-agents/              # User's custom agents
+│   └── fullstack-guild/        # Example: guild added via add_source
 
 /usr/local/bin/cami             # Binary (on PATH)
 ```
@@ -314,9 +314,9 @@ Claude: *uses mcp__cami__update_claude_md*
 User: "Show me my agent sources"
 Claude: *uses mcp__cami__list_sources*
 "You have 2 agent sources:
- • ✓ lando-agents (priority 100) - 29 agents
-   Path: ~/cami-workspace/sources/lando-agents
-   Git: git@github.com:lando-labs/lando-agents.git (clean)
+ • ✓ fullstack-guild (priority 100) - 7 agents
+   Path: ~/cami-workspace/sources/fullstack-guild
+   Git: https://github.com/lando-labs/fullstack-guild.git (clean)
    Compliance: ✓ Compliant
 
  • ⚠️ team-agents (priority 50) - 15 agents
@@ -343,21 +343,14 @@ Claude: *uses mcp__cami__list_sources*
 
 **Example context**:
 ```
-User: "Add the official Lando agent library"
-Claude: *uses mcp__cami__add_source with git@github.com:lando-labs/lando-agents.git*
-"✓ Cloned lando-agents to ~/cami-workspace/sources/lando-agents
- ✓ Found 29 agents
+User: "Add the fullstack-guild"
+Claude: *uses mcp__cami__add_source with url="https://github.com/lando-labs/fullstack-guild.git"*
+"✓ Cloned fullstack-guild to ~/cami-workspace/sources/fullstack-guild
+ ✓ Found 7 agents
 
  ## Source Compliance Check
 
- ⚠️ **This source has compliance issues:**
-
- - Missing .camiignore file
- - 3 agents with issues:
-   - frontend.md: missing version
-   - backend.md: missing version, missing description
-
- **Recommendation:** Use `normalize_source` to fix these issues automatically."
+ ✓ **Source is compliant**"
 ```
 
 #### 7. `mcp__cami__update_source`
@@ -375,7 +368,7 @@ Claude: *uses mcp__cami__add_source with git@github.com:lando-labs/lando-agents.
 ```
 User: "Update my agents"
 Claude: *uses mcp__cami__update_source*
-"✓ Updated lando-agents (3 new commits)
+"✓ Updated fullstack-guild (3 new commits)
  ⊘ Skipped my-agents (no git remote)"
 ```
 
@@ -391,7 +384,7 @@ Claude: *uses mcp__cami__update_source*
 ```
 User: "Check my agent sources"
 Claude: *uses mcp__cami__source_status*
-"lando-agents: Clean (on main, up to date with remote)
+"fullstack-guild: Clean (on main, up to date with remote)
  my-agents: Modified (2 uncommitted changes)"
 ```
 
@@ -467,9 +460,11 @@ Claude: *uses mcp__cami__remove_location*
 User: "Help me get started with CAMI"
 Claude: *uses mcp__cami__onboard*
 "I see CAMI isn't configured yet. Let me help you set it up.
- I'll add the official Lando agent library with 29 professional agents."
+ What kind of development do you primarily do?"
+User: "Full stack web apps"
+Claude: "I recommend the fullstack-guild - it has agents for React, Express, MongoDB, and more."
 *uses mcp__cami__add_source*
-"✓ Added lando-agents (29 agents available)
+"✓ Added fullstack-guild (7 agents available)
  Which agents would you like to add to your project?"
 ```
 
@@ -755,11 +750,12 @@ User: "I want to start using CAMI"
 
 Claude workflow:
 1. Use mcp__cami__onboard → Detect no config
-2. Use mcp__cami__add_source → Clone lando-agents
-3. Use mcp__cami__list_agents → Show available agents
-4. Ask user which agents they want
-5. Use mcp__cami__deploy_agents → Deploy selected agents
-6. Use mcp__cami__update_claude_md → Document deployment
+2. Ask user about development focus
+3. Use mcp__cami__add_source → Clone appropriate guild (fullstack-guild, content-guild, or game-dev-guild)
+4. Use mcp__cami__list_agents → Show available agents
+5. Ask user which agents they want
+6. Use mcp__cami__deploy_agents → Deploy selected agents
+7. Use mcp__cami__update_claude_md → Document deployment
 ```
 
 ### Adding Agents to Current Project
@@ -847,11 +843,11 @@ When the same agent exists in multiple sources, CAMI uses priority-based dedupli
 
 ```yaml
 agent_sources:
-  - name: official-agents
-    priority: 100        # Official agents (lowest priority)
+  - name: fullstack-guild
+    priority: 100        # Public guilds (lowest priority)
 
-  - name: company-agents
-    priority: 50         # Company-specific (medium priority)
+  - name: team-agents
+    priority: 50         # Team-specific (medium priority)
 
   - name: my-agents
     priority: 10         # Personal overrides (highest priority)

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ $ cami scan ~/projects/my-app
 ├── .claude/
 │   └── agents/                  # CAMI's own agents
 ├── sources/                     # Agent sources
-│   ├── official-agents/        # (if added)
+│   ├── my-agents/              # Your custom agents
 │   ├── team-agents/            # (if added)
-│   └── my-agents/              # Your custom agents
+│   └── fullstack-guild/        # Example: guild added via add_source
 
 /usr/local/bin/cami             # Binary on PATH
 ```
@@ -118,8 +118,8 @@ agent_sources:
     priority: 10         # Highest priority (personal overrides)
   - name: team-agents
     priority: 50         # Medium priority (default)
-  - name: official-agents
-    priority: 100        # Lowest priority (public agents)
+  - name: fullstack-guild
+    priority: 100        # Lowest priority (public guilds)
 ```
 
 **Example**: If "frontend" agent exists in all three sources, the version from `my-agents` (priority 10) is used.

--- a/install/templates/CLAUDE.md
+++ b/install/templates/CLAUDE.md
@@ -72,7 +72,7 @@ You: *uses add_source with url="https://github.com/lando-labs/content-guild.git"
 │   ├── my-agents/              # Your custom agents
 │   │   └── .camiignore         # Exclude files from agent loading
 │   ├── team-agents/            # Team agents (if added)
-│   └── official-agents/        # Official library (if added)
+│   └── fullstack-guild/        # Example: added via add_source
 └── README.md                    # Quick start guide
 ```
 
@@ -200,7 +200,29 @@ Me: *creates each agent individually, saves to my-agents*
 
 Ask: **"Help me get started with CAMI"**
 
-I'll guide you through adding agent sources and setting up your first agents.
+For first-time users, I recommend adding one of the official Lando Labs agent guilds based on your development focus:
+
+| Guild | Best For | Agents |
+|-------|----------|--------|
+| `fullstack-guild` | MERN stack web development | ~7 agents |
+| `content-guild` | Writing, marketing, documentation | ~6 agents |
+| `game-dev-guild` | Phaser 3 game development | ~8 agents |
+
+**Example first-time setup:**
+```
+User: "Help me get started with CAMI"
+You: "What kind of development do you primarily do?"
+User: "Full stack web apps with React and Node"
+You: "I recommend the fullstack-guild - it has agents for React frontend,
+     Express backend, MongoDB, and more. Want me to add it?"
+User: "Yes"
+You: *uses add_source with url="https://github.com/lando-labs/fullstack-guild.git"*
+```
+
+Alternatively, users can:
+- Create custom agents from scratch using agent-architect
+- Add their company/team's agent library
+- Start with just `my-agents/` and build their own collection
 
 ### Deploying Agents to a Project
 
@@ -336,13 +358,13 @@ agent_sources:
     git:
       enabled: false
 
-  - name: official-agents
+  - name: fullstack-guild      # Example: added via add_source
     type: local
-    path: ~/cami-workspace/sources/official-agents
-    priority: 100        # Lower priority (defaults)
+    path: ~/cami-workspace/sources/fullstack-guild
+    priority: 100
     git:
       enabled: true
-      remote: git@github.com:example/agents.git
+      remote: https://github.com/lando-labs/fullstack-guild.git
 
 deploy_locations:
   - name: my-app

--- a/install/templates/README.md
+++ b/install/templates/README.md
@@ -46,9 +46,9 @@ CAMI will guide you through adding agent sources and configuring your setup.
 ├── .claude/
 │   └── agents/                  # CAMI's own agents (qa, agent-architect, etc.)
 ├── sources/                     # Agent sources
-│   ├── official-agents/        # Official agent library (if added)
+│   ├── my-agents/              # Your custom agents
 │   ├── team-agents/            # Team agents (if added)
-│   └── my-agents/              # Your custom agents
+│   └── fullstack-guild/        # Example: guild added via add_source
 └── README.md                    # This file
 ```
 
@@ -82,8 +82,20 @@ Agents are organized in `sources/` directory:
 
 - **my-agents/** - Your custom agents (tracked in git if you initialize this directory)
   - Includes a `.camiignore` file to exclude non-agent files from loading
-- **official-agents/** - Official agent library (pulled from remote)
+- **[guild-name]/** - Agent guilds added via `add_source` (e.g., fullstack-guild, content-guild)
 - **team-agents/** - Your team's shared agents (pulled from remote)
+
+### Official Agent Guilds
+
+Lando Labs maintains public agent guilds you can add:
+
+| Guild | Focus |
+|-------|-------|
+| `fullstack-guild` | MERN stack web development |
+| `content-guild` | Writing & marketing |
+| `game-dev-guild` | Phaser 3 game development |
+
+Add a guild: `"Add the fullstack-guild"`
 
 ### Adding Agent Sources
 
@@ -107,7 +119,7 @@ When the same agent exists in multiple sources, **lower priority number wins**:
 - Priority 50 = Default (standard sources)
 - Priority 100 = Lowest (fallback defaults)
 
-Example: If "frontend" agent exists in both `my-agents` (priority 10) and `official-agents` (priority 100), the version from `my-agents` is used.
+Example: If "frontend" agent exists in both `my-agents` (priority 10) and `fullstack-guild` (priority 100), the version from `my-agents` is used.
 
 ### Excluding Files with .camiignore
 


### PR DESCRIPTION
## Summary
- Fixes #4 - Onboarding incorrectly suggested 'lando-agents' repo which is private
- Replace all references to 'official-agents' and 'lando-agents' with public guilds
- Add explicit First Time Setup guidance with guild table (fullstack-guild, content-guild, game-dev-guild)
- Improve onboarding workflow to ask about development focus before recommending guilds

## Changes
- **install/templates/CLAUDE.md**: Added First Time Setup section with guild table, updated all examples
- **install/templates/README.md**: Added Official Agent Guilds section, updated directory structure
- **README.md**: Updated example config and directory structure
- **CLAUDE.md**: Updated all workflow examples and priority deduplication example

## Test plan
- [ ] Run `make install` to create fresh workspace
- [ ] Verify `~/cami-workspace/CLAUDE.md` has guild table
- [ ] Verify `~/cami-workspace/README.md` mentions guilds
- [ ] Test onboarding flow asks about development focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)