### PR TITLE
fix: replace stale vc-agents references with sources

### DIFF
--- a/.claude/commands/cami-new-agent.md
+++ b/.claude/commands/cami-new-agent.md
@@ -23,7 +23,7 @@ Invoke the @agent-architect agent with these instructions:
 **User Requirements**: $ARGUMENTS
 
 **Technical Requirements**:
-- Target Directory: /Users/lando/Development/cami/vc-agents
+- Target Directory: ~/cami-workspace/sources/my-agents
 - Starting Version: 1.0.0
 - Must follow CAMI agent architecture standards
 - Must include complete YAML frontmatter (name, version, description, tags, use_cases, color, model)
@@ -33,7 +33,7 @@ Invoke the @agent-architect agent with these instructions:
 - Include version numbers for technical specialists (e.g., React 19+, Node.js 18+)
 - Set appropriate model (opus for complex reasoning, sonnet for most agents)
 
-Please create a production-ready agent file and save it to the vc-agents directory."
+Please create a production-ready agent file and save it to the sources/my-agents directory."
 
 Wait for @agent-architect to complete the agent design and save the file.
 
@@ -54,7 +54,7 @@ After agent creation, verify:
   • Name: [agent-name]
   • Version: [version]
   • Description: [description]
-  • Location: /Users/lando/Development/cami/vc-agents/[agent-name].md
+  • Location: ~/cami-workspace/sources/my-agents/[agent-name].md
 
 🚀 To deploy this agent to a project, use the CAMI MCP tools:
 
@@ -83,7 +83,7 @@ If @agent-architect encounters issues:
 ## Quality Checklist
 
 Before presenting results, verify:
-- [ ] Agent file exists in vc-agents/
+- [ ] Agent file exists in sources/my-agents/
 - [ ] Agent has valid YAML frontmatter with all required fields
 - [ ] Agent includes PROACTIVELY language in description
 - [ ] Agent follows appropriate archetype template

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -140,7 +140,7 @@ func shouldIgnore(relPath string, patterns []string) bool {
 	return false
 }
 
-// LoadAgents reads all agents from the vc-agents directory (supports nested folders)
+// LoadAgents reads all agents from the sources directory (supports nested folders)
 func LoadAgents(vcAgentsDir string) ([]*Agent, error) {
 	var agents []*Agent
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -39,7 +39,7 @@ func InitCommand() error {
 
 	// Ask where to store agents
 	fmt.Println("? Where should we store your agents?")
-	fmt.Println("  1. ./vc-agents (default, in this directory)")
+	fmt.Println("  1. ./sources (default, in this directory)")
 	fmt.Println("  2. Specify custom path")
 	fmt.Print("\nChoice (1): ")
 
@@ -47,38 +47,38 @@ func InitCommand() error {
 	choice, _ := reader.ReadString('\n')
 	choice = strings.TrimSpace(choice)
 
-	var vcAgentsPath string
+	var sourcesPath string
 	if choice == "" || choice == "1" {
-		// Default: ./vc-agents
+		// Default: ./sources
 		cwd, err := os.Getwd()
 		if err != nil {
 			return fmt.Errorf("failed to get current directory: %w", err)
 		}
-		vcAgentsPath = filepath.Join(cwd, "vc-agents")
+		sourcesPath = filepath.Join(cwd, "sources")
 	} else if choice == "2" {
 		fmt.Print("Path: ")
 		path, _ := reader.ReadString('\n')
-		vcAgentsPath = strings.TrimSpace(path)
+		sourcesPath = strings.TrimSpace(path)
 
 		// Expand ~ to home directory
-		if strings.HasPrefix(vcAgentsPath, "~/") {
+		if strings.HasPrefix(sourcesPath, "~/") {
 			home, err := os.UserHomeDir()
 			if err != nil {
 				return fmt.Errorf("failed to get home directory: %w", err)
 			}
-			vcAgentsPath = filepath.Join(home, vcAgentsPath[2:])
+			sourcesPath = filepath.Join(home, sourcesPath[2:])
 		}
 	} else {
 		return fmt.Errorf("invalid choice: %s", choice)
 	}
 
-	// Create vc-agents structure
-	vcAgentsPath, err = filepath.Abs(vcAgentsPath)
+	// Create sources structure
+	sourcesPath, err = filepath.Abs(sourcesPath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve path: %w", err)
 	}
 
-	myAgentsPath := filepath.Join(vcAgentsPath, "my-agents")
+	myAgentsPath := filepath.Join(sourcesPath, "my-agents")
 	if err := os.MkdirAll(myAgentsPath, 0755); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}

--- a/internal/cli/init_cmd.go
+++ b/internal/cli/init_cmd.go
@@ -12,7 +12,7 @@ func NewInitCommand() *cobra.Command {
 		Long: `Initialize CAMI configuration with workspace setup.
 
 This command sets up:
-  - Agent workspace directory (vc-agents/)
+  - Agent sources directory (sources/)
   - Default local source (my-agents/)
   - Configuration file ($CAMI_DIR/config.yaml, defaults to ~/cami-workspace/)`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -32,7 +32,7 @@ func NewListCommand(vcAgentsDir string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List available agents",
-		Long:  `List all available agents from the vc-agents directory.`,
+		Long:  `List all available agents from configured sources.`,
 		Example: `  cami list
   cami list --output json`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -43,7 +43,7 @@ func NewSourceAddCommand() *cobra.Command {
 		Short: "Add a new agent source",
 		Long: `Add a new agent source by cloning a Git repository.
 
-The repository will be cloned to vc-agents/<name>/ and added to your configuration.
+The repository will be cloned to sources/<name>/ and added to your configuration.
 
 Examples:
   cami source add git@github.com:company/agents.git
@@ -130,7 +130,7 @@ func NewSourceRemoveCommand() *cobra.Command {
 		Long: `Remove an agent source from configuration.
 
 Note: This only removes the source from configuration, it does not delete
-the directory. Use 'rm -rf vc-agents/<name>' to delete the files.`,
+the directory. Use 'rm -rf sources/<name>' to delete the files.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return SourceRemoveCommand(args[0])
@@ -155,20 +155,20 @@ func SourceAddCommand(url, name string, priority int) error {
 		}
 	}
 
-	// Find vc-agents directory
-	vcAgentsDir, err := findVCAgentsDir()
+	// Find sources directory
+	sourcesDir, err := findSourcesDir()
 	if err != nil {
-		return fmt.Errorf("failed to find vc-agents directory: %w", err)
+		return fmt.Errorf("failed to find sources directory: %w", err)
 	}
 
-	targetPath := filepath.Join(vcAgentsDir, name)
+	targetPath := filepath.Join(sourcesDir, name)
 
 	// Check if directory already exists
 	if _, err := os.Stat(targetPath); err == nil {
 		return fmt.Errorf("directory already exists: %s", targetPath)
 	}
 
-	fmt.Printf("Cloning %s to vc-agents/%s...\n", url, name)
+	fmt.Printf("Cloning %s to sources/%s...\n", url, name)
 
 	// Clone repository
 	cmd := exec.Command("git", "clone", url, targetPath)
@@ -204,7 +204,7 @@ func SourceAddCommand(url, name string, priority int) error {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
-	fmt.Printf("\n✓ Cloned %s to vc-agents/%s\n", name, name)
+	fmt.Printf("\n✓ Cloned %s to sources/%s\n", name, name)
 	fmt.Printf("✓ Added source with priority %d\n", priority)
 	if agents != nil {
 		fmt.Printf("✓ Found %d agents\n", len(agents))
@@ -383,8 +383,8 @@ func SourceRemoveCommand(name string) error {
 
 	fmt.Printf("✓ Removed source %q from configuration\n", name)
 	fmt.Println()
-	fmt.Printf("Note: Directory vc-agents/%s still exists.\n", name)
-	fmt.Printf("Remove it manually with: rm -rf vc-agents/%s\n", name)
+	fmt.Printf("Note: Directory sources/%s still exists.\n", name)
+	fmt.Printf("Remove it manually with: rm -rf sources/%s\n", name)
 
 	return nil
 }
@@ -407,17 +407,17 @@ func deriveNameFromURL(url string) string {
 	return name
 }
 
-func findVCAgentsDir() (string, error) {
+func findSourcesDir() (string, error) {
 	// Try current directory first
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
 
-	vcAgentsPath := filepath.Join(cwd, "vc-agents")
-	if _, err := os.Stat(vcAgentsPath); err == nil {
-		return vcAgentsPath, nil
+	sourcesPath := filepath.Join(cwd, "sources")
+	if _, err := os.Stat(sourcesPath); err == nil {
+		return sourcesPath, nil
 	}
 
-	return "", fmt.Errorf("vc-agents directory not found (run from CAMI directory or run 'cami init' first)")
+	return "", fmt.Errorf("sources directory not found (run from CAMI workspace or run 'cami init' first)")
 }


### PR DESCRIPTION
## Summary
Replace all legacy `vc-agents` references with the current `sources/` naming convention.

This was discovered while investigating untracked sources in the workspace - the old naming could have caused confusion or path mismatches.

## Changes
- `internal/cli/source.go`: Update all user-facing messages and rename `findVCAgentsDir()` → `findSourcesDir()`
- `internal/cli/init.go`: Update prompts and path construction  
- `internal/cli/init_cmd.go`: Update help text
- `internal/cli/list.go`: Update help text
- `internal/agent/agent.go`: Update comment
- `.claude/commands/cami-new-agent.md`: Update paths and references

## Test plan
- [ ] `go build ./cmd/cami` compiles
- [ ] `cami init` shows "sources" not "vc-agents" in prompts
- [ ] `cami source add --help` shows correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)