### PR TITLE
feat: add source reconciliation for detecting untracked sources

### DIFF
--- a/install/templates/.claude/settings.json
+++ b/install/templates/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "cami source reconcile --check-only --quiet"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `cami source reconcile` CLI command with --check-only, --quiet, --auto-add flags
- Add `reconcile_sources` MCP tool for Claude Code integration  
- Add SessionStart hook template to auto-detect untracked sources on session start
- Update install.sh to deploy .claude/settings.json with hook configuration

Closes #9

## Problem

Sources could be manually cloned to `~/cami-workspace/sources/` outside the MCP workflow (e.g., `git clone` directly) and not get tracked in `config.yaml`. This happens when Claude creates sources during long conversations without using the proper CAMI tools, resulting in orphaned sources that CAMI doesn't know about.

## Solution

The reconcile feature:
- Compares sources/ directory contents with config.yaml
- Detects untracked sources (on disk but not in config)
- Detects orphaned configs (in config but not on disk)
- Provides auto-add option to fix untracked sources
- SessionStart hook runs on Claude Code session start (quiet when in sync)

This ensures that even if sources are created incorrectly, they'll be detected and can be added to tracking on the next session start.

## CLI Usage

```bash
cami source reconcile              # Interactive mode
cami source reconcile --check-only # Just report issues
cami source reconcile --quiet      # Silent when in sync (for hooks)
cami source reconcile --auto-add   # Auto-fix untracked sources
```

## MCP Tool

```
reconcile_sources(check_only=false, auto_add=false)
```

## Test plan

- [x] Build compiles successfully
- [x] All existing tests pass
- [x] CLI command works from cami-workspace
- [x] --quiet flag produces no output when in sync
- [x] Code is properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)