### PR TITLE
fix: resolve WSL installation issues with line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Shell scripts must always use LF line endings
+*.sh text eol=lf
+
+# Makefiles must use LF
+Makefile text eol=lf
+
+# Go files
+*.go text eol=lf
+
+# Config files
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+
+# Windows batch files should use CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build: ## Build CAMI binary for current platform
 
 install: build ## Build and install CAMI locally
 	@echo "Installing CAMI..."
-	./install/install.sh
+	@bash ./install/install.sh
 	@echo "✓ Installation complete!"
 
 clean: ## Remove build artifacts


### PR DESCRIPTION
## Summary

- Add `.gitattributes` to enforce LF line endings for shell scripts
- Update Makefile to explicitly use `bash` for install script

Closes #8

## Problem

On WSL, when the repo is cloned with Windows git, shell scripts may get CRLF line endings. This causes the "No such file or directory" error because the shell interpreter line (`#!/bin/bash\r`) can't be found.

## Solution

1. **`.gitattributes`**: Enforces LF line endings for all shell scripts, Makefiles, and other text files regardless of the user's git configuration
2. **Makefile**: Explicitly calls `bash ./install/install.sh` instead of relying on the shebang line

## For existing clones

Users who already cloned with CRLF endings should run:
```bash
git rm --cached -r .
git reset --hard
```

Or re-clone the repository.

## Test plan

- [x] Makefile still works on macOS/Linux
- [x] .gitattributes correctly specifies line endings

🤖 Generated with [Claude Code](https://claude.com/claude-code)