### PR TITLE
fix: update agent-architect to v4.1.0 with documentation strategy

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -161,7 +161,7 @@ cp "$TEMPLATE_DIR/.gitignore" "$INSTALL_DIR/"
 cp "$TEMPLATE_DIR/.mcp.json" "$INSTALL_DIR/"
 
 # Deploy agent-architect (the only bundled agent)
-print_info "Deploying agent-architect v4.0.0..."
+print_info "Deploying agent-architect v4.1.0..."
 cp "$TEMPLATE_DIR/agent-architect.md" "$INSTALL_DIR/.claude/agents/"
 
 # Deploy settings.json with SessionStart hook for reconciliation

--- a/install/templates/agent-architect.md
+++ b/install/templates/agent-architect.md
@@ -1,6 +1,6 @@
 ---
 name: agent-architect
-version: "4.0.0"
+version: "4.1.0"
 description: Use this agent PROACTIVELY when you need to create, refine, or optimize Claude Code agent configurations. This includes designing new agents from scratch, improving existing agent system prompts, establishing agent interaction patterns, defining agent responsibilities and boundaries, or architecting multi-agent systems with clear separation of concerns.
 class: strategic-planner
 specialty: agent-design
@@ -382,7 +382,22 @@ You are [Expert Identity with version-specific expertise if applicable]...
 **Tools**: [Recommended tools for this phase]
 
 ## Documentation Strategy
-[How this agent documents its work]
+
+**Location**: Check STRATEGIES.yaml for `documentation.location`, otherwise use `<project-root>/reference/`
+
+**AI-Generated Documentation Marking**: When creating markdown documentation files (technical docs, ADRs, design documents, API docs), add a header comment:
+
+```markdown
+<!--
+AI-Generated Documentation
+Created by: [this-agent-name]
+Date: YYYY-MM-DD
+Purpose: [brief description]
+-->
+```
+
+**Apply headers to**: `.md` files in docs directories, ADRs, technical design docs, API documentation
+**Never mark**: Source code, config files, root README.md, package.json, etc.
 
 ## Decision-Making Framework
 [Structured decision criteria for the domain]
@@ -504,6 +519,8 @@ Every agent you create must:
 
 ## Agent Output Guidelines
 
+**CRITICAL**: The guidance in this section must be EMBEDDED into every agent you create. Agents you design will produce their own documentation and artifacts - they need these guidelines built into their system prompts, not just documented here for your reference.
+
 When agents you create produce documentation or artifacts, they should follow these guidelines:
 
 ### Documentation Location
@@ -552,5 +569,6 @@ Before finalizing any agent design, ask yourself:
 6. Are auxiliary functions appropriate and necessary for the specialty?
 7. Will this agent work harmoniously with others in the ecosystem?
 8. If creating for a specific source: Does the agent align with the source's STRATEGIES.yaml guidance?
+9. Does the Documentation Strategy section include AI-generated header marking guidance?
 
 You are not just creating agents - you are architecting a symphony of specialized intelligence, where each instrument plays its part with mastery and purpose.


### PR DESCRIPTION
## Summary

Update the bundled agent-architect from v4.0.0 to v4.1.0 to fix agents being created without proper documentation practices.

Closes #15

## Key Improvements in v4.1.0

### Documentation Strategy Section (lines 384-400)
Tells agents WHERE to put documentation and HOW to mark AI-generated content:
- Check STRATEGIES.yaml for `documentation.location` first
- Default to `<project-root>/reference/`
- Add AI-generated header to markdown docs

### Agent Output Guidelines Section (lines 522-560)
**CRITICAL**: This guidance must be EMBEDDED into every agent created. Includes:
- Documentation location rules
- AI-generated marking requirements
- What files to mark vs. never mark

### Self-Verification Update
Added check: "Does the Documentation Strategy section include AI-generated header marking guidance?"

## Problem This Fixes

Agents were being created without:
- Knowing where to put documentation
- Marking AI-generated docs properly
- Embedding documentation guidelines into their own system prompts

## Upgrade Guide

See Issue #15 for guidance on updating existing agents created with v4.0.0.

## Test plan

- [x] Template file updated to v4.1.0
- [x] Install script references correct version
- [x] Content matches working cami-workspace version

🤖 Generated with [Claude Code](https://claude.com/claude-code)