### PR TITLE
fix: derive version from binary instead of hardcoded values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INSTALL_DIR=$(HOME)/cami
 BIN_DIR=/usr/local/bin
 
 # Go build flags
-LDFLAGS=-ldflags "-X main.Version=$(VERSION)"
+LDFLAGS=-ldflags "-X main.version=$(VERSION)"
 
 help: ## Show this help message
 	@echo "CAMI Makefile"

--- a/cmd/cami/main.go
+++ b/cmd/cami/main.go
@@ -23,18 +23,28 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const version = "0.4.0"
+// version is set via ldflags during build: -X main.version=<tag>
+// Falls back to "dev" for local development builds
+var version = "dev"
 
 // MCP server constants
-const (
-	serverName    = "cami"
-	serverVersion = "0.4.0"
-)
+const serverName = "cami"
+
+// displayVersion returns a formatted version string for display
+// Handles both "dev" and git describe output like "v0.4.4" or "v0.4.4-1-gabcdef"
+func displayVersion() string {
+	// If version already starts with 'v', don't add another one
+	if strings.HasPrefix(version, "v") {
+		return version
+	}
+	// For "dev" or other non-prefixed versions, add the 'v'
+	return "v" + version
+}
 
 // ========== CLI FUNCTIONS ==========
 
 func printHelp() {
-	fmt.Printf("CAMI v%s - Claude Agent Management Interface\n\n", version)
+	fmt.Printf("CAMI %s - Claude Agent Management Interface\n\n", displayVersion())
 	fmt.Println("A tool for managing and deploying Claude Code agents.")
 	fmt.Println()
 	fmt.Println("USAGE:")
@@ -227,7 +237,7 @@ func runCLI() {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "-v", "--version":
-			fmt.Printf("CAMI v%s\n", version)
+			fmt.Printf("CAMI %s\n", displayVersion())
 			fmt.Println("Claude Agent Management Interface")
 			os.Exit(0)
 		case "-h", "--help":
@@ -418,14 +428,14 @@ func runMCPServer() {
 	// Create MCP server
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    serverName,
-		Version: serverVersion,
+		Version: version,
 	}, nil)
 
 	// Register all MCP tools
 	registerMCPTools(server)
 
 	// Start server with stdio transport
-	log.Printf("Starting CAMI MCP server v%s", serverVersion)
+	log.Printf("Starting CAMI MCP server %s", displayVersion())
 	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
 		log.Fatalf("Server error: %v", err)
 	}


### PR DESCRIPTION
## Summary
Removes hardcoded version numbers and derives version from binary itself.

Fixes #17

## Changes

**cmd/cami/main.go:**
- Change `const version` to `var version` so ldflags can inject it
- Default to `"dev"` for local development builds
- Add `displayVersion()` helper to handle v-prefix correctly (prevents double-v like `vv0.4.4`)

**Makefile:**
- Fix ldflags from `-X main.Version` to `-X main.version` (lowercase)

**install/install.sh:**
- Read version from binary instead of hardcoded value
- Single source of truth: git tag → binary → install script
- Warn and prompt user confirmation for dev builds
- Error if version extraction fails

## Version Flow
```
git tag (v0.4.4)
    ↓
git describe (v0.4.4 or v0.4.4-1-gabcdef)
    ↓
make build (ldflags inject into binary)
    ↓
install.sh (reads from binary)
```

## Test Plan
- [x] `go build` without ldflags → shows "CAMI vdev"
- [x] `make build` → shows correct git describe version (e.g., "CAMI v0.4.4-1-gabcdef")
- [x] Version extraction in install.sh works correctly
- [x] Dev build prompts user for confirmation
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)